### PR TITLE
Add salary calculation and time tracking

### DIFF
--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -2,6 +2,7 @@
 session_start();
 require_once __DIR__ . '/../../config/database.php';
 require_once __DIR__ . '/../models/User.php';
+require_once __DIR__ . '/../models/Task.php';
 
 if(!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin'){
     header("Location: ../views/login.php");
@@ -10,6 +11,7 @@ if(!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin'){
 
 $db = (new Database())->getConnection();
 $user = new User($db);
+$taskModel = new Task($db);
 
 $action = $_GET['action'] ?? 'list';
 
@@ -20,11 +22,31 @@ switch ($action) {
             $user->email = $_POST['email'];
             $user->password = $_POST['password'];
             $user->role = $_POST['role'];
+            $user->hourly_rate = $_POST['hourly_rate'];
             $user->create();
             header("Location: AdminController.php?action=list");
             exit;
         }
         include __DIR__ . '/../views/admin/users/create.php';
+        break;
+
+    case 'salary':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $user->id = $_POST['user_id'];
+            $user->hourly_rate = $_POST['hourly_rate'];
+            $user->updateHourlyRate();
+        }
+        $users = $user->readAll();
+        $employees = [];
+        foreach($users as $u){
+            if($u['role'] !== 'admin'){
+                $hours = $taskModel->sumHoursByUser($u['id']);
+                $u['total_hours'] = $hours;
+                $u['salary'] = $hours * (float)$u['hourly_rate'];
+                $employees[] = $u;
+            }
+        }
+        include __DIR__ . '/../views/admin/users/salary.php';
         break;
 
     default:

--- a/app/controllers/ProjectController.php
+++ b/app/controllers/ProjectController.php
@@ -3,10 +3,12 @@ session_start();
 require_once __DIR__ . '/../../config/database.php';
 require_once __DIR__ . '/../models/Project.php';
 require_once __DIR__ . '/../models/User.php';
+require_once __DIR__ . '/../models/Task.php';
 
 $db = (new Database())->getConnection();
 $project = new Project($db);
 $userModel = new User($db);
+$taskModel = new Task($db);
 
 $action = $_GET['action'] ?? 'list';
 
@@ -69,6 +71,9 @@ switch ($action) {
             $projects = $project->readAll();
         } else {
             $projects = $project->readByUser($_SESSION['user_id']);
+        }
+        foreach($projects as &$p){
+            $p['total_hours'] = $taskModel->sumHoursByProject($p['id']);
         }
         include __DIR__ . '/../views/projects/list.php';
         break;

--- a/app/controllers/RegisterController.php
+++ b/app/controllers/RegisterController.php
@@ -11,6 +11,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
     $user->email = $_POST['email'];
     $user->password = $_POST['password'];
     $user->role = 'programmer';
+    $user->hourly_rate = 0;
     if($user->create()){
         $logged = $user->login();
         if($logged){

--- a/app/controllers/TaskController.php
+++ b/app/controllers/TaskController.php
@@ -27,6 +27,7 @@ switch ($action) {
             $task->assigned_to = $assignedUsers[0] ?? null;
             $task->due_date = $_POST['due_date'];
             $task->status = $_POST['status'] ?? 'pending'; // ✅ usar el estado del formulario
+            $task->estimated_hours = $_POST['estimated_hours'];
             $newId = $task->create();
             if($newId && $assignedUsers){
                 $task->assignUsers($newId, $assignedUsers);
@@ -49,6 +50,7 @@ switch ($action) {
             $task->assigned_to = $assignedUsers[0] ?? null;
             $task->due_date = $_POST['due_date'];
             $task->status = $_POST['status'];
+            $task->estimated_hours = $_POST['estimated_hours'];
             $task->update();
             $task->clearUsers($task->id);
             if($assignedUsers){
@@ -60,6 +62,7 @@ switch ($action) {
         $data = $task->readOne();
         $assigned = $task->getUsers($task->id);
         $projects = $projectModel->readAll();
+        $users = $userModel->readAll();
         include __DIR__ . '/../views/tasks/edit.php';
         break;
 

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -8,19 +8,21 @@ class User {
     public $email;
     public $password;
     public $role;
+    public $hourly_rate;
 
     public function __construct($db){
         $this->conn = $db;
     }
 
     public function create(){
-        $query = "INSERT INTO " . $this->table_name . " (name, email, password, role)
-                  VALUES (:name, :email, :password, :role)";
+        $query = "INSERT INTO " . $this->table_name . " (name, email, password, role, hourly_rate)
+                  VALUES (:name, :email, :password, :role, :hourly_rate)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":name", $this->name);
         $stmt->bindParam(":email", $this->email);
         $stmt->bindParam(":password", password_hash($this->password, PASSWORD_BCRYPT));
         $stmt->bindParam(":role", $this->role);
+        $stmt->bindParam(":hourly_rate", $this->hourly_rate);
         return $stmt->execute();
     }
 
@@ -38,8 +40,16 @@ class User {
     }
 
     public function readAll(){
-        $stmt = $this->conn->query("SELECT id, name, email, role FROM " . $this->table_name);
+        $stmt = $this->conn->query("SELECT id, name, email, role, hourly_rate FROM " . $this->table_name);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function updateHourlyRate(){
+        $query = "UPDATE " . $this->table_name . " SET hourly_rate=:hourly_rate WHERE id=:id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':hourly_rate', $this->hourly_rate);
+        $stmt->bindParam(':id', $this->id);
+        return $stmt->execute();
     }
 }
 ?>

--- a/app/views/admin/users/create.php
+++ b/app/views/admin/users/create.php
@@ -22,6 +22,10 @@
         <input type="password" name="password" required class="border p-2 w-full rounded">
     </div>
     <div>
+        <label class="block mb-1">Valor por hora:</label>
+        <input type="number" step="0.01" name="hourly_rate" required class="border p-2 w-full rounded">
+    </div>
+    <div>
         <label class="block mb-1">Rol:</label>
         <select name="role" class="border p-2 w-full rounded">
             <option value="admin">Administrador</option>

--- a/app/views/admin/users/list.php
+++ b/app/views/admin/users/list.php
@@ -16,6 +16,7 @@
             <th class="border p-2">Nombre</th>
             <th class="border p-2">Email</th>
             <th class="border p-2">Rol</th>
+            <th class="border p-2">Valor hora</th>
         </tr>
     </thead>
     <tbody>
@@ -25,6 +26,7 @@
             <td class="border p-2"><?php echo htmlspecialchars($u['name']); ?></td>
             <td class="border p-2"><?php echo htmlspecialchars($u['email']); ?></td>
             <td class="border p-2"><?php echo htmlspecialchars($u['role']); ?></td>
+            <td class="border p-2 text-right"><?php echo $u['hourly_rate']; ?></td>
         </tr>
     <?php endforeach; ?>
     </tbody>

--- a/app/views/admin/users/salary.php
+++ b/app/views/admin/users/salary.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Sueldos</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 w-screen h-screen overflow-x-hidden m-0 p-0">
+<?php include __DIR__ . '/../../layout/header.php'; ?>
+<h1 class="text-2xl font-bold mb-4">Calculadora de Sueldos</h1>
+<table class="mt-4 w-full border-collapse border">
+    <thead>
+        <tr class="bg-gray-200">
+            <th class="border p-2">Nombre</th>
+            <th class="border p-2">Valor hora</th>
+            <th class="border p-2">Horas asignadas</th>
+            <th class="border p-2">Sueldo</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach($employees as $e): ?>
+        <tr class="bg-white">
+            <td class="border p-2"><?php echo htmlspecialchars($e['name']); ?></td>
+            <td class="border p-2">
+                <form action="AdminController.php?action=salary" method="POST" class="flex space-x-2 items-center">
+                    <input type="hidden" name="user_id" value="<?php echo $e['id']; ?>">
+                    <input type="number" step="0.01" name="hourly_rate" value="<?php echo $e['hourly_rate']; ?>" class="border p-1 w-24 rounded">
+                    <button type="submit" class="text-blue-600">Guardar</button>
+                </form>
+            </td>
+            <td class="border p-2 text-center"><?php echo $e['total_hours']; ?></td>
+            <td class="border p-2 text-right">$<?php echo number_format($e['salary'], 2); ?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<a href="AdminController.php?action=list" class="inline-block mt-4 text-blue-600">Volver</a>
+</body>
+</html>

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -16,6 +16,7 @@ if (session_status() === PHP_SESSION_NONE) {
                 <a href="/app/controllers/TaskController.php?action=list" class="hover:text-gray-200 transition">Tareas</a>
                 <?php if($_SESSION['role'] === 'admin'): ?>
                     <a href="/app/controllers/AdminController.php?action=list" class="hover:text-gray-200 transition">Usuarios</a>
+                    <a href="/app/controllers/AdminController.php?action=salary" class="hover:text-gray-200 transition">Sueldos</a>
                 <?php endif; ?>
             <?php endif; ?>
         </div>

--- a/app/views/projects/list.php
+++ b/app/views/projects/list.php
@@ -18,6 +18,7 @@
             <th class="border p-2">Nombre</th>
             <th class="border p-2">Descripción</th>
             <th class="border p-2">Fechas</th>
+            <th class="border p-2">Horas totales</th>
             <th class="border p-2">Acciones</th>
         </tr>
     </thead>
@@ -28,6 +29,7 @@
             <td class="border p-2"><?php echo htmlspecialchars($p['name']); ?></td>
             <td class="border p-2"><?php echo htmlspecialchars($p['description']); ?></td>
             <td class="border p-2"><?php echo $p['start_date']; ?> - <?php echo $p['end_date']; ?></td>
+            <td class="border p-2 text-center"><?php echo $p['total_hours']; ?></td>
             <td class="border p-2 space-x-2">
 
                 <?php if($_SESSION['role'] === 'admin'): ?>

--- a/app/views/tasks/create.php
+++ b/app/views/tasks/create.php
@@ -24,6 +24,10 @@
         <input type="text" name="description" required class="border p-2 w-full rounded">
     </div>
     <div>
+        <label class="block mb-1">Tiempo estimado (horas):</label>
+        <input type="number" step="0.1" name="estimated_hours" required class="border p-2 w-full rounded">
+    </div>
+    <div>
         <label class="block mb-1">Asignar a:</label>
         <select id="members" name="assigned_to[]" multiple class="border p-2 w-full rounded">
             <?php foreach($users as $u): ?>

--- a/app/views/tasks/edit.php
+++ b/app/views/tasks/edit.php
@@ -35,6 +35,10 @@ if(!isset($_SESSION['user_id'])){
         <input type="text" name="description" value="<?php echo htmlspecialchars($data['description']); ?>" required class="border p-2 w-full rounded">
     </div>
     <div>
+        <label class="block mb-1">Tiempo estimado (horas):</label>
+        <input type="number" step="0.1" name="estimated_hours" value="<?php echo htmlspecialchars($data['estimated_hours']); ?>" required class="border p-2 w-full rounded">
+    </div>
+    <div>
         <label class="block mb-1">Asignar a:</label>
         <select name="assigned_to" class="border p-2 w-full rounded">
             <?php foreach($users as $u): ?>

--- a/app/views/tasks/list.php
+++ b/app/views/tasks/list.php
@@ -17,6 +17,7 @@
                 <p class="font-medium"><?php echo htmlspecialchars($t['description']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['project_name']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['users']); ?></p>
+                <p class="text-sm text-gray-600">Horas: <?php echo $t['estimated_hours']; ?></p>
                 <p class="text-sm">
                     <?php echo $t['due_date']; ?>
                     <?php if(strtotime($t['due_date']) < strtotime('+2 day')): ?>
@@ -34,6 +35,7 @@
                 <p class="font-medium"><?php echo htmlspecialchars($t['description']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['project_name']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['users']); ?></p>
+                <p class="text-sm text-gray-600">Horas: <?php echo $t['estimated_hours']; ?></p>
                 <p class="text-sm"><?php echo $t['due_date']; ?></p>
                 <a href="TaskController.php?action=edit&id=<?php echo $t['id']; ?>" class="text-blue-600 text-sm">Editar</a>
             </div>
@@ -46,6 +48,7 @@
                 <p class="font-medium"><?php echo htmlspecialchars($t['description']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['project_name']); ?></p>
                 <p class="text-sm text-gray-600"><?php echo htmlspecialchars($t['users']); ?></p>
+                <p class="text-sm text-gray-600">Horas: <?php echo $t['estimated_hours']; ?></p>
                 <p class="text-sm"><?php echo $t['due_date']; ?></p>
                 <a href="TaskController.php?action=edit&id=<?php echo $t['id']; ?>" class="text-blue-600 text-sm">Editar</a>
             </div>


### PR DESCRIPTION
## Summary
- add hourly rate support and salary calculator for admins
- track estimated hours per task and sum hours per project/user
- display total project hours

## Testing
- `php -l app/models/User.php`
- `php -l app/models/Task.php`
- `php -l app/controllers/TaskController.php`
- `php -l app/controllers/ProjectController.php`
- `php -l app/controllers/AdminController.php`
- `php -l app/controllers/RegisterController.php`
- `php -l app/views/projects/list.php`
- `php -l app/views/tasks/create.php`
- `php -l app/views/tasks/edit.php`
- `php -l app/views/tasks/list.php`
- `php -l app/views/admin/users/create.php`
- `php -l app/views/admin/users/list.php`
- `php -l app/views/admin/users/salary.php`
- `php -l app/views/layout/header.php`

------
https://chatgpt.com/codex/tasks/task_e_689a3a71481083299fb30fbe9c4fa84d