### PR TITLE
feat: add client debt management

### DIFF
--- a/app/controllers/ClientController.php
+++ b/app/controllers/ClientController.php
@@ -1,0 +1,58 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../models/Client.php';
+require_once __DIR__ . '/../models/Debt.php';
+require_once __DIR__ . '/../models/Project.php';
+
+if(!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin','leader'])){
+    header("Location: ../views/login.php");
+    exit;
+}
+
+$db = (new Database())->getConnection();
+$client = new Client($db);
+$debt = new Debt($db);
+$projectModel = new Project($db);
+
+$action = $_GET['action'] ?? 'list';
+
+switch ($action) {
+    case 'create':
+        if($_SERVER['REQUEST_METHOD'] === 'POST'){
+            $client->name = $_POST['name'];
+            $client->create();
+            header("Location: ClientController.php?action=list");
+            exit;
+        }
+        include __DIR__ . '/../views/clients/create.php';
+        break;
+
+    case 'view':
+        $client->id = $_GET['id'];
+        $data = $client->readOne();
+        $debts = $debt->readByClient($client->id);
+        include __DIR__ . '/../views/clients/view.php';
+        break;
+
+    case 'addDebt':
+        $client_id = $_GET['client_id'];
+        if($_SERVER['REQUEST_METHOD'] === 'POST'){
+            $debt->client_id = $client_id;
+            $debt->project_id = $_POST['project_id'];
+            $debt->title = $_POST['title'];
+            $debt->description = $_POST['description'];
+            $debt->create();
+            header("Location: ClientController.php?action=view&id=" . $client_id);
+            exit;
+        }
+        $projects = $projectModel->readAll();
+        include __DIR__ . '/../views/clients/addDebt.php';
+        break;
+
+    default:
+        $clients = $client->readAll();
+        include __DIR__ . '/../views/clients/list.php';
+        break;
+}
+?>

--- a/app/models/Client.php
+++ b/app/models/Client.php
@@ -1,0 +1,31 @@
+<?php
+class Client {
+    private $conn;
+    private $table_name = "clients";
+
+    public $id;
+    public $name;
+
+    public function __construct($db){
+        $this->conn = $db;
+    }
+
+    public function create(){
+        $stmt = $this->conn->prepare("INSERT INTO " . $this->table_name . " (name) VALUES (:name)");
+        $stmt->bindParam(":name", $this->name);
+        return $stmt->execute();
+    }
+
+    public function readAll(){
+        $stmt = $this->conn->query("SELECT * FROM " . $this->table_name);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function readOne(){
+        $stmt = $this->conn->prepare("SELECT * FROM " . $this->table_name . " WHERE id=:id");
+        $stmt->bindParam(":id", $this->id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/app/models/Debt.php
+++ b/app/models/Debt.php
@@ -1,0 +1,34 @@
+<?php
+class Debt {
+    private $conn;
+    private $table_name = "debts";
+
+    public $id;
+    public $client_id;
+    public $project_id;
+    public $title;
+    public $description;
+
+    public function __construct($db){
+        $this->conn = $db;
+    }
+
+    public function create(){
+        $query = "INSERT INTO " . $this->table_name . " (client_id, project_id, title, description) VALUES (:client_id, :project_id, :title, :description)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(":client_id", $this->client_id);
+        $stmt->bindParam(":project_id", $this->project_id);
+        $stmt->bindParam(":title", $this->title);
+        $stmt->bindParam(":description", $this->description);
+        return $stmt->execute();
+    }
+
+    public function readByClient($client_id){
+        $query = "SELECT d.*, p.name AS project_name FROM " . $this->table_name . " d LEFT JOIN projects p ON d.project_id = p.id WHERE d.client_id = :cid";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(":cid", $client_id);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/app/views/clients/addDebt.php
+++ b/app/views/clients/addDebt.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Nueva Deuda</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 w-screen h-screen overflow-x-hidden m-0 p-0">
+<?php include __DIR__ . '/../layout/header.php'; ?>
+<h1 class="text-2xl font-bold mb-4">Nueva Deuda</h1>
+<form method="POST" action="ClientController.php?action=addDebt&client_id=<?php echo $client_id; ?>" class="space-y-4">
+    <input type="text" name="title" placeholder="Título" required class="border p-2 w-full rounded">
+    <textarea name="description" placeholder="Descripción" required class="border p-2 w-full rounded"></textarea>
+    <select name="project_id" class="border p-2 w-full rounded" required>
+        <?php foreach($projects as $p): ?>
+        <option value="<?php echo $p['id']; ?>"><?php echo htmlspecialchars($p['name']); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Guardar</button>
+</form>
+</body>
+</html>

--- a/app/views/clients/create.php
+++ b/app/views/clients/create.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Nuevo Cliente</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 w-screen h-screen overflow-x-hidden m-0 p-0">
+<?php include __DIR__ . '/../layout/header.php'; ?>
+<h1 class="text-2xl font-bold mb-4">Nuevo Cliente</h1>
+<form method="POST" action="ClientController.php?action=create" class="space-y-4">
+    <input type="text" name="name" placeholder="Nombre" required class="border p-2 w-full rounded">
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Guardar</button>
+</form>
+</body>
+</html>

--- a/app/views/clients/list.php
+++ b/app/views/clients/list.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Clientes</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 w-screen h-screen overflow-x-hidden m-0 p-0">
+<?php include __DIR__ . '/../layout/header.php'; ?>
+<h1 class="text-2xl font-bold mb-4">Clientes</h1>
+<a href="ClientController.php?action=create" class="bg-blue-500 text-white px-4 py-2 rounded">Nuevo cliente</a>
+<table class="mt-4 w-full border-collapse border">
+    <thead>
+        <tr class="bg-gray-200">
+            <th class="border p-2">ID</th>
+            <th class="border p-2">Nombre</th>
+            <th class="border p-2">Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach($clients as $c): ?>
+        <tr class="bg-white">
+            <td class="border p-2 text-center"><?php echo $c['id']; ?></td>
+            <td class="border p-2"><?php echo htmlspecialchars($c['name']); ?></td>
+            <td class="border p-2">
+                <a href="ClientController.php?action=view&id=<?php echo $c['id']; ?>" class="text-blue-600">Ver</a>
+            </td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+</body>
+</html>

--- a/app/views/clients/view.php
+++ b/app/views/clients/view.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Cliente</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 w-screen h-screen overflow-x-hidden m-0 p-0">
+<?php include __DIR__ . '/../layout/header.php'; ?>
+<h1 class="text-2xl font-bold mb-4">Cliente: <?php echo htmlspecialchars($data['name']); ?></h1>
+<a href="ClientController.php?action=addDebt&client_id=<?php echo $data['id']; ?>" class="bg-blue-500 text-white px-4 py-2 rounded">Agregar Deuda</a>
+<table class="mt-4 w-full border-collapse border">
+    <thead>
+        <tr class="bg-gray-200">
+            <th class="border p-2">Título</th>
+            <th class="border p-2">Descripción</th>
+            <th class="border p-2">Proyecto</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach($debts as $d): ?>
+        <tr class="bg-white">
+            <td class="border p-2"><?php echo htmlspecialchars($d['title']); ?></td>
+            <td class="border p-2"><?php echo htmlspecialchars($d['description']); ?></td>
+            <td class="border p-2"><?php echo htmlspecialchars($d['project_name']); ?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+</body>
+</html>

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -14,6 +14,9 @@ if (session_status() === PHP_SESSION_NONE) {
                 <a href="/app/views/dashboard.php" class="hover:text-gray-200 transition">Dashboard</a>
                 <a href="/app/controllers/ProjectController.php?action=list" class="hover:text-gray-200 transition">Proyectos</a>
                 <a href="/app/controllers/TaskController.php?action=list" class="hover:text-gray-200 transition">Tareas</a>
+                <?php if(in_array($_SESSION['role'], ['admin','leader'])): ?>
+                    <a href="/app/controllers/ClientController.php?action=list" class="hover:text-gray-200 transition">Clientes</a>
+                <?php endif; ?>
                 <?php if($_SESSION['role'] === 'admin'): ?>
                     <a href="/app/controllers/AdminController.php?action=list" class="hover:text-gray-200 transition">Usuarios</a>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add client and debt models
- add controller and views for managing client debts
- show Clients section for admins and leaders

## Testing
- `php -l app/models/Client.php`
- `php -l app/models/Debt.php`
- `php -l app/controllers/ClientController.php`
- `php -l app/views/clients/list.php`
- `php -l app/views/clients/create.php`
- `php -l app/views/clients/view.php`
- `php -l app/views/clients/addDebt.php`
- `php -l app/views/layout/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689a2d35de1c8329bd40fd86c82e58b1